### PR TITLE
Focus and text fields

### DIFF
--- a/lib/forms/textfield_focus.dart
+++ b/lib/forms/textfield_focus.dart
@@ -1,0 +1,60 @@
+// https://flutter.dev/docs/cookbook/forms/focus
+
+import 'package:flutter/material.dart';
+
+class TextFieldFocus extends StatefulWidget {
+  @override
+  _TextFieldFocusState createState() => _TextFieldFocusState();
+}
+
+class _TextFieldFocusState extends State<TextFieldFocus> {
+  // Define the focus node. To manage the lifecycle, create the FocusNode in
+  // the initState method, and clean it up in the dispose method.
+  FocusNode myFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+
+    myFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    // Clean up the focus node when the Form is disposed.
+    myFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Text Field Focus'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            // The first text field is focused on as soon as the app starts.
+            TextField(
+              autofocus: true,
+            ),
+            // The second text field is focused on when a user taps the
+            // FloatingActionButton.
+            TextField(
+              focusNode: myFocusNode,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        // When the button is pressed,
+        // give focus to the text field using myFocusNode.
+        onPressed: () => myFocusNode.requestFocus(),
+        tooltip: 'Focus Second Text Field',
+        child: Icon(Icons.edit),
+      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,8 @@ import 'package:google_fonts/google_fonts.dart';
 
 /*Forms */
 //import 'forms/form_validation.dart';
-import 'forms/form_custom.dart';
+//import 'forms/form_custom.dart';
+import 'forms/textfield_focus.dart';
 
 main() {
   // runApp(MaterialApp(
@@ -40,7 +41,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         textTheme: GoogleFonts.ralewayTextTheme(Theme.of(context).textTheme),
       ),
-      home: CustomForm(),
+      home: TextFieldFocus(),
     );
   }
 }


### PR DESCRIPTION
Focus and text fields

- Focus a text field as soon as it’s visible
- Focus a text field when a button is tapped
    1. Create a FocusNode
    2. Pass the FocusNode to a TextField
    3. Give focus to the TextField when a button is tapped

https://flutter.dev/docs/cookbook/forms/focus