### PR TITLE
Add Material touch ripples

### DIFF
--- a/lib/gestures/touch_ripples.dart
+++ b/lib/gestures/touch_ripples.dart
@@ -1,0 +1,29 @@
+// https://flutter.dev/docs/cookbook/gestures/ripples
+
+import 'package:flutter/material.dart';
+
+class TouchRipples extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Touch ripples'),
+      ),
+      body: Center(
+        child: InkWell(
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Tap ripples'),
+              ),
+            );
+          },
+          child: Container(
+            padding: EdgeInsets.all(12.0),
+            child: Text('Flat button'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,10 @@ import 'package:google_fonts/google_fonts.dart';
 /*Forms */
 //import 'forms/form_validation.dart';
 //import 'forms/form_custom.dart';
-import 'forms/textfield_focus.dart';
+//import 'forms/textfield_focus.dart';
+
+/*Gestures */
+import 'gestures/touch_ripples.dart';
 
 main() {
   // runApp(MaterialApp(
@@ -41,7 +44,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         textTheme: GoogleFonts.ralewayTextTheme(Theme.of(context).textTheme),
       ),
-      home: TextFieldFocus(),
+      home: TouchRipples(),
     );
   }
 }


### PR DESCRIPTION
Add Material touch ripples

1. Create a widget that supports tap.
2. Wrap it in an InkWell widget to manage tap callbacks and ripple animations.

https://flutter.dev/docs/cookbook/gestures/ripples
