### PR TITLE
Pass arguments to a named route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,8 +43,12 @@ import 'package:google_fonts/google_fonts.dart';
 /*Navigation */
 // import 'navigation/nav_hero/main_screen.dart';
 //import 'navigation/nav_routes/first_route.dart';
-import 'navigation/nav_name_routes/firstscreen.dart';
-import 'navigation/nav_name_routes/secondscreem.dart';
+//import 'navigation/nav_name_routes/firstscreen.dart';
+//import 'navigation/nav_name_routes/secondscreem.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/extract_screen.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/home_screen.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/pass_screen.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/screen_arguments.dart';
 
 main() {
   // runApp(MaterialApp(
@@ -83,18 +87,55 @@ class MyApp extends StatelessWidget {
     // );
 
     //SAMPLE ANIMATE NAVIGATE
+    // return MaterialApp(
+    //   title: 'Navigation Basics',
+    //   //home: FirstRoute(), //Comment this if using NavigationRoutes
+    //   // Start the app with the "/" named route. In this case, the app starts
+    //   // on the FirstScreen widget.
+    //   initialRoute: '/',
+    //   routes: {
+    //     // When navigating to the "/" route, build the FirstScreen widget.
+    //     '/': (context) => FirstScreen(),
+    //     // When navigating to the "/second" route, build the SecondScreen widget.
+    //     '/second': (context) => SecondScreen(),
+    //   },
+    // );
+
+    ///ADVANCE MATERIAL NAVIGATION
+    ///Pass arguments to a named route
     return MaterialApp(
-      title: 'Navigation Basics',
-      //home: FirstRoute(), //Comment this if using NavigationRoutes
-      // Start the app with the "/" named route. In this case, the app starts
-      // on the FirstScreen widget.
-      initialRoute: '/',
-      routes: {
-        // When navigating to the "/" route, build the FirstScreen widget.
-        '/': (context) => FirstScreen(),
-        // When navigating to the "/second" route, build the SecondScreen widget.
-        '/second': (context) => SecondScreen(),
-      },
-    );
+        // Provide a function to handle named routes. Use this function to
+        // identify the named route being pushed, and create the correct
+        // Screen.
+        onGenerateRoute: (settings) {
+          // If you push the PassArguments route
+          if (settings.name == PassArgumentsScreen.routeName) {
+            // Cast the arguments to the correct type: ScreenArguments.
+            final ScreenArguments args = settings.arguments;
+
+            // Then, extract the required data from the arguments and
+            // pass the data to the correct screen.
+            return MaterialPageRoute(
+              builder: (context) {
+                return PassArgumentsScreen(
+                  title: args.title,
+                  message: args.message,
+                );
+              },
+            );
+          }
+          // The code only supports PassArgumentsScreen.routeName right now.
+          // Other values need to be implemented if we add them. The assertion
+          // here will help remind us of that higher up in the call stack, since
+          // this assertion would otherwise fire somewhere in the framework.
+          assert(false, 'Need to implement ${settings.name}');
+          return null;
+        },
+        title: 'Navigation with Arguments',
+        home: HomeScreen(),
+        routes: {
+          ExtractArgumentsScreen.routeName: (context) =>
+              ExtractArgumentsScreen(),
+        });
   }
 }

--- a/lib/navigation/nav_extract_routenames/extract_screen.dart
+++ b/lib/navigation/nav_extract_routenames/extract_screen.dart
@@ -1,0 +1,25 @@
+// https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments
+
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/screen_arguments.dart';
+import 'package:flutter/material.dart';
+
+// A widget that extracts the necessary arguments from the ModalRoute.
+class ExtractArgumentsScreen extends StatelessWidget {
+  static const routeName = '/extractArguments';
+
+  @override
+  Widget build(BuildContext context) {
+    // Extract the arguments from the current ModalRoute settings and cast
+    // them as ScreenArguments.
+    final ScreenArguments args = ModalRoute.of(context).settings.arguments;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(args.title),
+      ),
+      body: Center(
+        child: Text(args.message),
+      ),
+    );
+  }
+}

--- a/lib/navigation/nav_extract_routenames/home_screen.dart
+++ b/lib/navigation/nav_extract_routenames/home_screen.dart
@@ -1,0 +1,59 @@
+// https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments
+
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/extract_screen.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/pass_screen.dart';
+import 'package:cookbook_flutter/navigation/nav_extract_routenames/screen_arguments.dart';
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Home Screen'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            // A button that navigates to a named route that. The named route
+            // extracts the arguments by itself.
+            ElevatedButton(
+              child: Text("Navigate to screen that extracts arguments"),
+              onPressed: () {
+                // When the user taps the button, navigate to a named route
+                // and provide the arguments as an optional parameter.
+                Navigator.pushNamed(
+                  context,
+                  ExtractArgumentsScreen.routeName,
+                  arguments: ScreenArguments(
+                    'Extract Arguments Screen',
+                    'This message is extracted in the build method.',
+                  ),
+                );
+              },
+            ),
+            // A button that navigates to a named route. For this route, extract
+            // the arguments in the onGenerateRoute function and pass them
+            // to the screen.
+            ElevatedButton(
+              child: Text("Navigate to a named that accepts arguments"),
+              onPressed: () {
+                // When the user taps the button, navigate to a named route
+                // and provide the arguments as an optional parameter.
+                Navigator.pushNamed(
+                  context,
+                  PassArgumentsScreen.routeName,
+                  arguments: ScreenArguments(
+                    'Accept Arguments Screen',
+                    'This message is extracted in the onGenerateRoute function.',
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/navigation/nav_extract_routenames/pass_screen.dart
+++ b/lib/navigation/nav_extract_routenames/pass_screen.dart
@@ -1,0 +1,34 @@
+// https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments
+
+import 'package:flutter/material.dart';
+
+// A Widget that accepts the necessary arguments via the constructor.
+class PassArgumentsScreen extends StatelessWidget {
+  static const routeName = '/passArguments';
+
+  final String title;
+  final String message;
+
+  // This Widget accepts the arguments as constructor parameters. It does not
+  // extract the arguments from the ModalRoute.
+  //
+  // The arguments are extracted by the onGenerateRoute function provided to the
+  // MaterialApp widget.
+  const PassArgumentsScreen({
+    Key key,
+    @required this.title,
+    @required this.message,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Center(
+        child: Text(message),
+      ),
+    );
+  }
+}

--- a/lib/navigation/nav_extract_routenames/screen_arguments.dart
+++ b/lib/navigation/nav_extract_routenames/screen_arguments.dart
@@ -1,0 +1,11 @@
+// https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments
+
+// You can pass any object to the arguments parameter.
+// In this example, create a class that contains a customizable
+// title and message.
+class ScreenArguments {
+  final String title;
+  final String message;
+
+  ScreenArguments(this.title, this.message);
+}


### PR DESCRIPTION
Contents
1. Define the arguments you need to pass
2. Create a widget that extracts the arguments
3. Register the widget in the routes table
4. Navigate to the widget
Alternatively, extract the arguments using onGenerateRoute

https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments