### PR TITLE
An introduction to widget testing

### DIFF
--- a/lib/widget_testing/mywidget.dart
+++ b/lib/widget_testing/mywidget.dart
@@ -1,0 +1,29 @@
+// https://flutter.dev/docs/cookbook/testing/widget/introduction
+
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String title;
+  final String message;
+
+  const MyWidget({
+    Key key,
+    @required this.title,
+    @required this.message,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text(title),
+        ),
+        body: Center(
+          child: Text(message),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widget_testing/mywidget_test.dart
+++ b/lib/widget_testing/mywidget_test.dart
@@ -1,0 +1,22 @@
+// https://flutter.dev/docs/cookbook/testing/widget/introduction
+
+import 'package:cookbook_flutter/widget_testing/mywidget.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Define a test. The TestWidgets function also provides a WidgetTester
+  // to work with. The WidgetTester allows you to build and interact
+  // with widgets in the test environment.
+  testWidgets('MyWidget has a title and message', (WidgetTester tester) async {
+    await tester.pumpWidget(MyWidget(title: 'T', message: 'M'));
+
+    // Create the Finders.
+    final titleFinder = find.text('T');
+    final messageFinder = find.text('M');
+
+    // Use the `findsOneWidget` matcher provided by flutter_test to verify
+    // that the Text widgets appear exactly once in the widget tree.
+    expect(titleFinder, findsOneWidget);
+    expect(messageFinder, findsOneWidget);
+  });
+}


### PR DESCRIPTION
An introduction to widget testing

1. Add the flutter_test dependency.
2. Create a widget to test.
3. Create a testWidgets test.
4. Build the widget using the WidgetTester.
5. Search for the widget using a Finder.
6. Verify the widget using a Matcher.


https://flutter.dev/docs/cookbook/testing/widget/introduction